### PR TITLE
Fix typos in README.md and init.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ if spaceName then
             -- hotkey to change current space's name
             set={{"ctrl"}, "n"},
             -- hotkey to show menu with all spaces
-            show={{"ctrl}", "m"}
+            show={{"ctrl"}, "m"}
         })
 end
 ```

--- a/init.lua
+++ b/init.lua
@@ -111,7 +111,7 @@ function obj:_getMenuItems()
     table.insert(res, { title = "-" })
     table.insert(res, { title = "Set name", fn = obj._setSpaceName })
     table.insert(res, { title = "-" })
-    table.insert(res, { title = "Verson: " .. obj.version})
+    table.insert(res, { title = "Version: " .. obj.version})
 
     obj.log.d("getMenuItems: done.")
     return res

--- a/init.lua
+++ b/init.lua
@@ -65,7 +65,7 @@ function obj:_setSpaceName()
         currentName = ""
     end
     button, newName = hs.dialog.textPrompt(
-        "Screen name", "Please, eneter a readable name",
+        "Screen name", "Please, enter a readable name",
         currentName,
         "Save", "Cancel"
     )


### PR DESCRIPTION
README.md: Two characters were transposed, preventing initialisation.
init.lua: Fix typo visible in the menu bar item.